### PR TITLE
remove go prefix from version

### DIFF
--- a/ci/update-versions.sh
+++ b/ci/update-versions.sh
@@ -24,7 +24,6 @@ pushd source
         
     echo "CLAMAV_REST_VERSION=${clamav_rest_version}" > image/args/build-args.conf
     echo "GO_VERSION=${go_version}" >> image/args/build-args.conf
-    echo " " >> image/args/build-args.conf
 
     # Only commit if there are changes
     git_diff=$(git diff image/args/build-args.conf)

--- a/ci/update-versions.sh
+++ b/ci/update-versions.sh
@@ -3,7 +3,7 @@
 set -e
 
 clamav_rest_version=$(cat clamav-rest-release/version)
-go_version=$(curl -s "https://go.dev/VERSION?m=text" | head -n 1)
+go_version=$(curl -s "https://go.dev/VERSION?m=text" | head -n 1 | awk -F "go" '{print $2}')
 
 pushd source
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- removes the `go` prefix from the version in the docker build args file. 


## Security considerations

None
